### PR TITLE
feat: add user credential management

### DIFF
--- a/pages/credentials.vue
+++ b/pages/credentials.vue
@@ -1,0 +1,136 @@
+<template>
+  <div class="space-y-6">
+    <div>
+      <h1 class="text-3xl font-bold tracking-tight">Credentials</h1>
+      <p class="text-muted-foreground mt-2">Configure external service credentials</p>
+    </div>
+
+    <UCard>
+      <UForm :state="form" @submit.prevent="handleSubmit">
+        <UFormGroup label="AWS Access Key" class="mb-4">
+          <div class="flex items-center space-x-2">
+            <UInput
+              :type="showPlain ? 'text' : 'password'"
+              v-model="form.aws_access_key"
+              :placeholder="existing.aws_access_key && !showPlain ? '********' : ''"
+            />
+          </div>
+        </UFormGroup>
+
+        <UFormGroup label="AWS Secret Key" class="mb-4">
+          <UInput
+            :type="showPlain ? 'text' : 'password'"
+            v-model="form.aws_secret_key"
+            :placeholder="existing.aws_secret_key && !showPlain ? '********' : ''"
+          />
+        </UFormGroup>
+
+        <UFormGroup label="Mongo Username" class="mb-4">
+          <UInput
+            :type="showPlain ? 'text' : 'password'"
+            v-model="form.mongo_username"
+            :placeholder="existing.mongo_username && !showPlain ? '********' : ''"
+          />
+        </UFormGroup>
+
+        <UFormGroup label="Mongo Password" class="mb-4">
+          <UInput
+            :type="showPlain ? 'text' : 'password'"
+            v-model="form.mongo_password"
+            :placeholder="existing.mongo_password && !showPlain ? '********' : ''"
+          />
+        </UFormGroup>
+
+        <div class="flex justify-between items-center">
+          <UButton
+            v-if="canView"
+            @click.prevent="toggleView"
+            variant="ghost"
+            :label="showPlain ? 'Hide' : 'View'"
+          />
+          <UButton type="submit" color="primary">Save</UButton>
+        </div>
+      </UForm>
+    </UCard>
+  </div>
+</template>
+
+<script setup>
+const { apiRequest } = useApi();
+const mainStore = useMainStore();
+
+const form = reactive({
+  aws_access_key: '',
+  aws_secret_key: '',
+  mongo_username: '',
+  mongo_password: ''
+});
+
+const existing = reactive({
+  aws_access_key: false,
+  aws_secret_key: false,
+  mongo_username: false,
+  mongo_password: false
+});
+
+const showPlain = ref(false);
+const canView = computed(() => mainStore.permissions.includes('CREDENTIALS_VIEW'));
+
+const fetchCredentials = async () => {
+  const { data } = await apiRequest('/api/internal/credentials');
+  if (data) {
+    existing.aws_access_key = !!data.aws_access_key;
+    existing.aws_secret_key = !!data.aws_secret_key;
+    existing.mongo_username = !!data.mongo_username;
+    existing.mongo_password = !!data.mongo_password;
+    form.aws_access_key = '';
+    form.aws_secret_key = '';
+    form.mongo_username = '';
+    form.mongo_password = '';
+    showPlain.value = false;
+  }
+};
+
+const fetchPlainCredentials = async () => {
+  const { data } = await apiRequest('/api/internal/credentials?plain=true');
+  if (data) {
+    form.aws_access_key = data.aws_access_key || '';
+    form.aws_secret_key = data.aws_secret_key || '';
+    form.mongo_username = data.mongo_username || '';
+    form.mongo_password = data.mongo_password || '';
+    existing.aws_access_key = !!data.aws_access_key;
+    existing.aws_secret_key = !!data.aws_secret_key;
+    existing.mongo_username = !!data.mongo_username;
+    existing.mongo_password = !!data.mongo_password;
+    showPlain.value = true;
+  }
+};
+
+const toggleView = async () => {
+  if (showPlain.value) {
+    await fetchCredentials();
+  } else if (canView.value) {
+    await fetchPlainCredentials();
+  }
+};
+
+const handleSubmit = async () => {
+  const payload = {};
+  if (form.aws_access_key || !existing.aws_access_key) payload.aws_access_key = form.aws_access_key;
+  if (form.aws_secret_key || !existing.aws_secret_key) payload.aws_secret_key = form.aws_secret_key;
+  if (form.mongo_username || !existing.mongo_username) payload.mongo_username = form.mongo_username;
+  if (form.mongo_password || !existing.mongo_password) payload.mongo_password = form.mongo_password;
+  await apiRequest('/api/internal/credentials', {
+    method: 'PUT',
+    body: payload,
+    showSuccessToast: true,
+    successMessage: 'Credentials saved'
+  });
+  await fetchCredentials();
+};
+
+onMounted(async () => {
+  if (!mainStore.permissions.length) await mainStore.fetchPermissions();
+  await fetchCredentials();
+});
+</script>

--- a/server/api/internal/credentials.get.js
+++ b/server/api/internal/credentials.get.js
@@ -1,0 +1,13 @@
+import { credentialsInternalApi } from '~/server/services/credentials.services';
+import { checkRequestedPermissions } from '~/server/utils/permissions';
+import { getQuery } from 'h3';
+
+export default defineEventHandler(async (event) => {
+  const { plain } = getQuery(event);
+  if (plain === 'true') {
+    event.requestedClaims = ['CREDENTIALS_VIEW'];
+    await checkRequestedPermissions(event);
+    return credentialsInternalApi.internalCredentialsGet(event, true);
+  }
+  return credentialsInternalApi.internalCredentialsGet(event, false);
+});

--- a/server/api/internal/credentials.put.js
+++ b/server/api/internal/credentials.put.js
@@ -1,0 +1,5 @@
+import { credentialsInternalApi } from '~/server/services/credentials.services';
+
+export default defineEventHandler(async (event) => {
+  return credentialsInternalApi.internalCredentialsUpsert(event);
+});

--- a/server/database/models/index.js
+++ b/server/database/models/index.js
@@ -13,4 +13,5 @@ export { default as UserGroupModel } from './user-group.model.js'
 export { default as GroupPermissionModel } from './group-permission.model.js'
 
 // MongoDB configuration model
-export { default as MongoCollectionModel } from './mongo-collection.model.js' 
+export { default as MongoCollectionModel } from './mongo-collection.model.js'
+export { default as UserCredentialModel } from './user-credential.model.js'

--- a/server/database/models/user-credential.model.js
+++ b/server/database/models/user-credential.model.js
@@ -1,0 +1,34 @@
+import { executeSupabaseQuery } from '../supabase.js';
+import { CreateUserCredentialSchema, UpdateUserCredentialSchema } from '../schemas/index.js';
+
+class UserCredentialModel {
+  static TABLE_NAME = 'user_credentials';
+
+  static async findByUserId(supabase, userId) {
+    const query = supabase.from(this.TABLE_NAME).select('*').eq('user_id', userId).limit(1);
+    return executeSupabaseQuery(query);
+  }
+
+  static async upsert(supabase, userId, credentialData) {
+    const payload = { user_id: userId, ...credentialData };
+    const validatedData = CreateUserCredentialSchema.parse(payload);
+    const query = supabase.from(this.TABLE_NAME)
+      .upsert(validatedData, { onConflict: 'user_id' })
+      .select()
+      .limit(1);
+    return executeSupabaseQuery(query);
+  }
+
+  static async update(supabase, userId, updateData) {
+    const validatedData = UpdateUserCredentialSchema.parse(updateData);
+    validatedData.updated_at = new Date();
+    const query = supabase.from(this.TABLE_NAME)
+      .update(validatedData)
+      .eq('user_id', userId)
+      .select()
+      .limit(1);
+    return executeSupabaseQuery(query);
+  }
+}
+
+export default UserCredentialModel;

--- a/server/database/schemas/index.js
+++ b/server/database/schemas/index.js
@@ -7,6 +7,7 @@ export * from './permissions.schema.js';
 export * from './user-groups.schema.js';
 export * from './group-permissions.schema.js';
 export * from './user-profiles.schema.js';
+export * from './user-credentials.schema.js';
 
 // MongoDB configuration
 export * from './mongo-collections.schema.js';

--- a/server/database/schemas/user-credentials.schema.js
+++ b/server/database/schemas/user-credentials.schema.js
@@ -1,0 +1,22 @@
+import { z } from 'zod';
+
+export const UserCredentialSchema = z.object({
+  user_id: z.string().uuid(),
+  aws_access_key: z.string().nullable().optional(),
+  aws_secret_key: z.string().nullable().optional(),
+  mongo_username: z.string().nullable().optional(),
+  mongo_password: z.string().nullable().optional(),
+  created_at: z.date().optional(),
+  updated_at: z.date().optional()
+});
+
+export const CreateUserCredentialSchema = UserCredentialSchema.omit({
+  created_at: true,
+  updated_at: true
+});
+
+export const UpdateUserCredentialSchema = UserCredentialSchema.partial().omit({
+  user_id: true,
+  created_at: true,
+  updated_at: true
+});

--- a/server/services/credentials.services.js
+++ b/server/services/credentials.services.js
@@ -1,0 +1,55 @@
+import { UserCredentialModel } from '~/server/database/models';
+import { readBody, getQuery } from 'h3';
+
+const maskValue = (val) => (val ? '********' : null);
+
+const internalCredentialsGet = async (event, plain = false) => {
+  const supabase = event.context.supabase;
+  const userId = event.context.user.id;
+
+  const result = await UserCredentialModel.findByUserId(supabase, userId);
+  const cred = Array.isArray(result) ? result[0] : null;
+
+  if (!cred) {
+    return {
+      aws_access_key: null,
+      aws_secret_key: null,
+      mongo_username: null,
+      mongo_password: null
+    };
+  }
+
+  const { aws_access_key, aws_secret_key, mongo_username, mongo_password } = cred;
+
+  if (!plain) {
+    return {
+      aws_access_key: maskValue(aws_access_key),
+      aws_secret_key: maskValue(aws_secret_key),
+      mongo_username: maskValue(mongo_username),
+      mongo_password: maskValue(mongo_password)
+    };
+  }
+
+  return { aws_access_key, aws_secret_key, mongo_username, mongo_password };
+};
+
+const internalCredentialsUpsert = async (event) => {
+  const supabase = event.context.supabase;
+  const userId = event.context.user.id;
+  const body = await readBody(event);
+
+  const data = {
+    aws_access_key: body.aws_access_key ?? null,
+    aws_secret_key: body.aws_secret_key ?? null,
+    mongo_username: body.mongo_username ?? null,
+    mongo_password: body.mongo_password ?? null
+  };
+
+  await UserCredentialModel.upsert(supabase, userId, data);
+  return { status: 'success' };
+};
+
+export const credentialsInternalApi = {
+  internalCredentialsGet,
+  internalCredentialsUpsert
+};


### PR DESCRIPTION
## Summary
- add page for managing AWS and Mongo credentials
- store credentials in new Supabase table with masking support
- add internal APIs and models for user-specific credential access

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_689eda79be58832baf2bde94da497dea